### PR TITLE
Apple Movie Trailers Lite has been renamed.

### DIFF
--- a/720p/CustomSettings.xml
+++ b/720p/CustomSettings.xml
@@ -306,7 +306,7 @@
 						<label>$LOCALIZE[31401]</label>
 						<onclick>Skin.ToggleSetting(NoTrailers)</onclick>
 						<selected>Skin.HasSetting(NoTrailers)</selected>
-						<visible>system.hasaddon(plugin.video.apple.movie.trailers.lite)</visible>
+						<visible>system.hasaddon(plugin.video.the.trailers)</visible>
 					</control>					
 					<control type="radiobutton" id="400">
 						<include>SettingsLabel</include>

--- a/720p/Includes_Home1.xml
+++ b/720p/Includes_Home1.xml
@@ -291,12 +291,12 @@
 					<visible>!Skin.HasSetting(NoMusic)</visible>
 				</item>
 				<item id="13">
-					<description>Apple Trailers</description>
+					<description>Movie Trailers</description>
 					<label>$LOCALIZE[31334]</label>
 					<icon>special://skin/extras/home1/trailers.jpg</icon>
 					<thumb>$INFO[Skin.String(CustomTrailers)]</thumb>
-					<onclick>ActivateWindow(Videos,plugin://plugin.video.apple.movie.trailers.lite,return)</onclick>
-					<visible>system.hasaddon(plugin.video.apple.movie.trailers.lite) + !Skin.HasSetting(NoTrailers)</visible>
+					<onclick>ActivateWindow(Videos,plugin://plugin.video.the.trailers,return)</onclick>
+					<visible>system.hasaddon(plugin.video.the.trailers) + !Skin.HasSetting(NoTrailers)</visible>
 				</item>
 				<item id="6">
 					<description>Pictures</description>

--- a/720p/Includes_Home2.xml
+++ b/720p/Includes_Home2.xml
@@ -172,11 +172,11 @@
 					<visible>!Skin.HasSetting(NoMusic)</visible>
 				</item>
 				<item id="13">
-					<description>AppleTrailers</description>
+					<description>Movie Trailers</description>
 					<label>$LOCALIZE[31334]</label>
 					<icon>special://skin/extras/home2/icon_trailers.png</icon>
-					<onclick>ActivateWindow(Videos,plugin://plugin.video.apple.movie.trailers.lite,return)</onclick>
-					<visible>system.hasaddon(plugin.video.apple.movie.trailers.lite)</visible>
+					<onclick>ActivateWindow(Videos,plugin://plugin.video.the.trailers,return)</onclick>
+					<visible>system.hasaddon(plugin.video.the.trailers)</visible>
 				</item>
 				<item id="6">
 					<description>Pictures</description>


### PR DESCRIPTION
As of XBMC 11.0 (eden), the "Apple Movie Trailers Lite" addon has been renamed to "The Trailers".
