### PR TITLE
More appropriate viewtypes for each view.

### DIFF
--- a/720p/Viewtype_Banner.xml
+++ b/720p/Viewtype_Banner.xml
@@ -4,7 +4,7 @@
 			<visible>Control.IsVisible(511)</visible>
 			<!-- Browser -->
 			<control type="panel" id="511">
-				<viewtype label="$LOCALIZE[31286]">icon</viewtype>
+				<viewtype label="$LOCALIZE[31286]">wide</viewtype>
 				<posx>40</posx>
 				<posy>340</posy>
 				<height>192</height>

--- a/720p/Viewtype_BannerPoster.xml
+++ b/720p/Viewtype_BannerPoster.xml
@@ -4,7 +4,7 @@
 			<visible>Control.IsVisible(510)</visible>
 			<!-- Browser -->
 			<control type="panel" id="510">
-				<viewtype label="$LOCALIZE[31286] $LOCALIZE[31413]">icon</viewtype>
+				<viewtype label="$LOCALIZE[31286] $LOCALIZE[31413]">bigwide</viewtype>
 				<posx>400</posx>
 				<posy>50</posy>
 				<height>450</height>

--- a/720p/Viewtype_Coverflow.xml
+++ b/720p/Viewtype_Coverflow.xml
@@ -2909,7 +2909,7 @@
 					<height>10</height>
 					<include condition="!Skin.HasSetting(ViewLockdown)">OnUp7000</include>
 					<ondown>60</ondown>
-					<viewtype label="33031">list</viewtype>
+					<viewtype label="33031">wide</viewtype>
 					<pagecontrol>60</pagecontrol>
 					<orientation>horizontal</orientation>
 					<scrolltime>250</scrolltime>

--- a/720p/Viewtype_Fanart.xml
+++ b/720p/Viewtype_Fanart.xml
@@ -12,7 +12,7 @@
 				<ondown>60</ondown>
 				<onleft>504</onleft>
 				<onright>504</onright>
-				<viewtype label="20445">list</viewtype>
+				<viewtype label="20445">bigwrap</viewtype>
 				<orientation>horizontal</orientation>
 				<focusposition>1</focusposition>
 				<scrolltime>200</scrolltime>

--- a/720p/Viewtype_FanartBanner.xml
+++ b/720p/Viewtype_FanartBanner.xml
@@ -4,7 +4,7 @@
 			<visible>Control.IsVisible(508)</visible>
 			<!-- Browser -->
 			<control type="fixedlist" id="508">
-				<viewtype label="$LOCALIZE[20445] $LOCALIZE[31286]">icon</viewtype>
+				<viewtype label="$LOCALIZE[20445] $LOCALIZE[31286]">wide</viewtype>
 				<posx>658</posx>
 				<posy>52</posy>
 				<height>480</height>

--- a/720p/Viewtype_Files.xml
+++ b/720p/Viewtype_Files.xml
@@ -17,7 +17,7 @@
 				<include condition="!Skin.HasSetting(ViewLockdown)">OnLeft7000</include>
 				<onright>61</onright>
 				<scrolltime>160</scrolltime>
-				<viewtype label="31289">list</viewtype>
+				<viewtype label="31289">biglist</viewtype>
 				<orientation>vertical</orientation>
 				<preloaditems>2</preloaditems>
 				<focusposition>6</focusposition>

--- a/720p/Viewtype_Landscape.xml
+++ b/720p/Viewtype_Landscape.xml
@@ -12,7 +12,7 @@
 				<ondown>60</ondown>
 				<onleft>52</onleft>
 				<onright>52</onright>
-				<viewtype label="31291">list</viewtype>
+				<viewtype label="31291">icon</viewtype>
 				<orientation>horizontal</orientation>
 				<focusposition>2</focusposition>
 				<scrolltime>200</scrolltime>

--- a/720p/Viewtype_Logo.xml
+++ b/720p/Viewtype_Logo.xml
@@ -12,7 +12,7 @@
 				<ondown>60</ondown>
 				<onleft>56</onleft>
 				<onright>56</onright>
-				<viewtype label="31054">list</viewtype>
+				<viewtype label="31054">icon</viewtype>
 				<orientation>horizontal</orientation>
 				<focusposition>2</focusposition>
 				<scrolltime>200</scrolltime>

--- a/720p/Viewtype_PosterAndFanart.xml
+++ b/720p/Viewtype_PosterAndFanart.xml
@@ -132,7 +132,7 @@
 			</control>			
 			<!-- Browser -->
 			<control type="wraplist" id="550">
-				<viewtype label="31424">list</viewtype>
+				<viewtype label="31424">bigwrap</viewtype>
 				<posx>-100</posx>
 				<posy>40</posy>
 				<height>500</height>
@@ -141,7 +141,6 @@
 				<ondown>60</ondown>
 				<onleft>550</onleft>
 				<onright>550</onright>
-				<viewtype label="20445">list</viewtype>
 				<orientation>horizontal</orientation>
 				<focusposition>1</focusposition>
 				<scrolltime>200</scrolltime>

--- a/720p/Viewtype_Poster_Fixed.xml
+++ b/720p/Viewtype_Poster_Fixed.xml
@@ -4,7 +4,7 @@
 			<visible>Control.IsVisible(53)</visible>
 			<!-- Browser -->
 			<control type="fixedlist" id="53">
-				<viewtype label="31283">list</viewtype>
+				<viewtype label="31283">icon</viewtype>
 				<onleft>53</onleft>
 				<onright>53</onright>
 				<posx>20</posx>

--- a/720p/Viewtype_Poster_Large.xml
+++ b/720p/Viewtype_Poster_Large.xml
@@ -132,7 +132,7 @@
 			</control>			
 			<!-- Browser -->
 			<control type="wraplist" id="551">
-				<viewtype label="31430">list</viewtype>
+				<viewtype label="31430">bigwrap</viewtype>
 				<posx>-100</posx>
 				<posy>40</posy>
 				<height>500</height>
@@ -141,7 +141,6 @@
 				<ondown>60</ondown>
 				<onleft>550</onleft>
 				<onright>550</onright>
-				<viewtype label="20445">list</viewtype>
 				<orientation>horizontal</orientation>
 				<focusposition>1</focusposition>
 				<scrolltime>200</scrolltime>

--- a/720p/Viewtype_Poster_Wrap.xml
+++ b/720p/Viewtype_Poster_Wrap.xml
@@ -4,7 +4,7 @@
 			<visible>Control.IsVisible(57)</visible>
 			<!-- Browser -->
 			<control type="wraplist" id="57">
-				<viewtype label="31282">list</viewtype>
+				<viewtype label="31282">wrap</viewtype>
 				<onleft>57</onleft>
 				<onright>57</onright>
 				<posx>20</posx>

--- a/720p/Viewtype_TallGenre.xml
+++ b/720p/Viewtype_TallGenre.xml
@@ -22,7 +22,7 @@
 				<ondown>60</ondown>
 				<onleft>501</onleft>
 				<onright>501</onright>
-				<viewtype label="$LOCALIZE[31416]">list</viewtype>
+				<viewtype label="$LOCALIZE[31416]">bigwrap</viewtype>
 				<orientation>horizontal</orientation>
 				<focusposition>3</focusposition>
 				<scrolltime>200</scrolltime>


### PR DESCRIPTION
Set viewtype attribute for each view to something that more accurately describes what the view actually looks like.
