### PR TITLE
Eliminate flicker/slowdown on Home2 style.

### DIFF
--- a/720p/Includes_Home2.xml
+++ b/720p/Includes_Home2.xml
@@ -98,7 +98,11 @@
 			<orientation>horizontal</orientation>
 			<focusposition>3</focusposition>
 			<scrolltime>200</scrolltime>
-			<preloaditems>2</preloaditems>
+			<!-- Setting preloaditems to anything greater than zero currently causes -->
+			<!-- flickering/slowdown if any home items are hidden.  -->
+			<!-- See http://trac.xbmc.org/ticket/12145 and https://github.com/stoli/Metropolis/issues/21 -->
+			<!--<preloaditems>2</preloaditems>-->
+			<preloaditems>0</preloaditems>
 			<include>Animation_OpenCloseFade</include>
 			<include>Animation_FadedByMenu</include>
 			<itemlayout width="180" height="450">


### PR DESCRIPTION
When one or more items in the Home2 wraplist are hidden, the left-most item in the list would flicker when scrolling right.  One user on the forums also reported massive framerate drop in this condition.

The (temporary) fix appears to be to set preloaditems to 0 (zero).  This fixes the flickering that I've personally seen.  Although I don't know if it fixes the slowdown as well since I can't reproduce that here, I suspect that
it probably will.

For reference, see:

http://trac.xbmc.org/ticket/12145
https://github.com/stoli/Metropolis/issues/21
