### PR TITLE
Show music overlay whenever possible.

### DIFF
--- a/720p/DialogContentSettings.xml
+++ b/720p/DialogContentSettings.xml
@@ -1,6 +1,7 @@
 ﻿<window id="132">
 	<defaultcontrol always="true">3</defaultcontrol>
 	<include>Animation_OpenCloseFade</include>
+	<allowoverlay>yes</allowoverlay>
 	<coordinates>
 		<system>1</system>
 		<posx>0</posx>

--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -56,9 +56,7 @@
 			<animation effect="fade" start="100" end="0" time="400">Hidden</animation>
 		</control>
 	</include>
-	
-	
-		
+
 	<include name="Global_TimeWeekdayDetails">
 		<posx>1241</posx>
 		<posy>546</posy>
@@ -72,13 +70,7 @@
 		<control type="group">
 			<posx>12</posx>
 			<posy>40</posy>
-			<!--
-			<include>Animation_FadedByMenu</include>
-			-->
-				
 			<control type="image">
-				<!-- <include>Animation_FadedByMenu</include>
-				<include>Animation_OpenCloseFade</include> -->
 				<posx>1145</posx>
 				<posy>517</posy>
 				<width>30</width>
@@ -86,7 +78,6 @@
 				<texture>$INFO[Window(Weather).Property(Current.FanartCode),special://skin/extras/weather_icons/,.png]</texture>
 				<visible>!Skin.HasSetting(HideClockTemp) + Weather.IsFetched</visible>
 			</control>
-		
 			<control type="label">
 				<description>Temperature</description>
 				<posx>1241</posx>
@@ -185,82 +176,84 @@
 			</control>
 		</control>
 	</include>
-	
-	
+
 	<!-- Plot to show in all video viewtypes but NOT Video Info screen -->
 	<include name="Global_VideoPlot">
-		<posx>0</posx>
-		<posy>0</posy>
-		<include>Animation_HiddenByInfo</include>
-		<!-- Regular Plot -->
-		<control type="group">
-			<visible>!Skin.HasSetting(ShowAllMediaFlags) | [Skin.HasSetting(ShowAllMediaFlags) + Container.Content(tvshows)] | [Skin.HasSetting(ShowAllMediaFlags) + SubString(Container.FolderPath,plugin)]</visible>
-			<control type="textbox">
-				<posx>220</posx>
-				<posy>565</posy>
-				<width>840</width>
-				<height>135</height>
-				<align>left</align>
-				<info>ListItem.Plot</info>
-				<autoscroll time="4000" delay="16000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
-				<font>METF_PlotTextMedium</font>
-				<textcolor>LowerText</textcolor>
-				<visible>!Skin.HasSetting(Show_PlotOutline) | IsEmpty(ListItem.PlotOutline)</visible>
+		<control type="group" id="9900">
+			<posx>0</posx>
+			<posy>0</posy>
+			<include>Animation_HiddenByInfo</include>
+			<visible>!IsEmpty(ListItem.Plot) | !IsEmpty(ListItem.PlotOutline) | !IsEmpty(Container.ShowPlot)</visible>
+			<!-- Regular Plot -->
+			<control type="group">
+				<visible>!Skin.HasSetting(ShowAllMediaFlags) | [Skin.HasSetting(ShowAllMediaFlags) + Container.Content(tvshows)] | [Skin.HasSetting(ShowAllMediaFlags) + SubString(Container.FolderPath,plugin)]</visible>
+				<control type="textbox">
+					<posx>220</posx>
+					<posy>565</posy>
+					<width>840</width>
+					<height>135</height>
+					<align>left</align>
+					<info>ListItem.Plot</info>
+					<autoscroll time="4000" delay="16000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<font>METF_PlotTextMedium</font>
+					<textcolor>LowerText</textcolor>
+					<visible>!Skin.HasSetting(Show_PlotOutline) | IsEmpty(ListItem.PlotOutline)</visible>
+				</control>
+				<control type="textbox">
+					<posx>220</posx>
+					<posy>565</posy>
+					<width>840</width>
+					<height>135</height>
+					<align>left</align>
+					<info>ListItem.PlotOutline</info>
+					<autoscroll time="4000" delay="16000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<font>METF_PlotTextMedium</font>
+					<textcolor>LowerText</textcolor>
+					<visible>Skin.HasSetting(Show_PlotOutline) + !IsEmpty(ListItem.PlotOutline)</visible>
+				</control>
 			</control>
-			<control type="textbox">
-				<posx>220</posx>
-				<posy>565</posy>
-				<width>840</width>
-				<height>135</height>
-				<align>left</align>
-				<info>ListItem.PlotOutline</info>
-				<autoscroll time="4000" delay="16000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
-				<font>METF_PlotTextMedium</font>
-				<textcolor>LowerText</textcolor>
-				<visible>Skin.HasSetting(Show_PlotOutline) + !IsEmpty(ListItem.PlotOutline)</visible>
+			<!-- Plot Outline Option -->
+			<control type="group">
+				<visible>Skin.HasSetting(ShowAllMediaFlags) + [Container.Content(movies) | Container.Content(episodes) | Container.Content(MusicVideos)] + !SubString(Container.FolderPath,plugin)</visible>
+				<control type="textbox">
+					<posx>220</posx>
+					<posy>557</posy>
+					<width>840</width>
+					<height>88</height>
+					<align>left</align>
+					<info>ListItem.Plot</info>
+					<autoscroll time="4000" delay="12000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<font>METF_PlotTextSmall</font>
+					<textcolor>LowerText</textcolor>
+					<visible>!Skin.HasSetting(Show_PlotOutline) | IsEmpty(ListItem.PlotOutline)</visible>
+				</control>
+				<control type="textbox">
+					<posx>220</posx>
+					<posy>557</posy>
+					<width>840</width>
+					<height>88</height>
+					<align>left</align>
+					<info>ListItem.PlotOutline</info>
+					<autoscroll time="4000" delay="12000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<font>METF_PlotTextSmall</font>
+					<textcolor>LowerText</textcolor>
+					<visible>Skin.HasSetting(Show_PlotOutline) + !IsEmpty(ListItem.PlotOutline) + Container.Content(movies)</visible>
+				</control>
 			</control>
-		</control>
-		<!-- Plot Outline Option -->
-		<control type="group">
-			<visible>Skin.HasSetting(ShowAllMediaFlags) + [Container.Content(movies) | Container.Content(episodes) | Container.Content(MusicVideos)] + !SubString(Container.FolderPath,plugin)</visible>
-			<control type="textbox">
-				<posx>220</posx>
-				<posy>557</posy>
-				<width>840</width>
-				<height>88</height>
-				<align>left</align>
-				<info>ListItem.Plot</info>
-				<autoscroll time="4000" delay="12000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
-				<font>METF_PlotTextSmall</font>
-				<textcolor>LowerText</textcolor>
-				<visible>!Skin.HasSetting(Show_PlotOutline) | IsEmpty(ListItem.PlotOutline)</visible>
-			</control>
-			<control type="textbox">
-				<posx>220</posx>
-				<posy>557</posy>
-				<width>840</width>
-				<height>88</height>
-				<align>left</align>
-				<info>ListItem.PlotOutline</info>
-				<autoscroll time="4000" delay="12000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
-				<font>METF_PlotTextSmall</font>
-				<textcolor>LowerText</textcolor>
-				<visible>Skin.HasSetting(Show_PlotOutline) + !IsEmpty(ListItem.PlotOutline) + Container.Content(movies)</visible>
-			</control>
-		</control>
-		<!-- Seasons - TV Show Plot -->
-		<control type="group">
-			<visible>Container.Content(seasons)</visible>
-			<control type="textbox">
-				<posx>220</posx>
-				<posy>565</posy>
-				<width>840</width>
-				<height>135</height>
-				<align>left</align>
-				<info>Container.ShowPlot</info>
-				<autoscroll time="4000" delay="16000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
-				<font>METF_PlotTextMedium</font>
-				<textcolor>LowerText</textcolor>
+			<!-- Seasons - TV Show Plot -->
+			<control type="group">
+				<visible>Container.Content(seasons)</visible>
+				<control type="textbox">
+					<posx>220</posx>
+					<posy>565</posy>
+					<width>840</width>
+					<height>135</height>
+					<align>left</align>
+					<info>Container.ShowPlot</info>
+					<autoscroll time="4000" delay="16000" repeat="8000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<font>METF_PlotTextMedium</font>
+					<textcolor>LowerText</textcolor>
+				</control>
 			</control>
 		</control>
 	</include>
@@ -271,16 +264,18 @@
 		<include>Animation_HiddenByInfo</include>
 		<control type="grouplist">
 			<visible>Window.IsActive(pictures)</visible>
-			<posx>220</posx>
+			<posx>340</posx>
 			<posy>565</posy>
-			<width>840</width>
-			<height>135</height>
-			<align>left</align>
+			<width>600</width>
+			<height>72</height>
+			<align>center</align>
+			<aligny>top</aligny>
 			<orientation>vertical</orientation>
 			<!-- Camera Info -->
 			<control type="label">
-				<width>840</width>
+				<width>600</width>
 				<height>20</height>
+				<align>center</align>
 				<font>METF_PlotTextMedium</font>
 				<textcolor>LowerText</textcolor>
 				<label>$INFO[ListItem.PictureCamMake] $INFO[ListItem.PictureCamModel]</label>
@@ -288,13 +283,13 @@
 			</control>
 			<!-- Focus and Aperture -->
 			<control type="grouplist">
-				<width>840</width>
+				<width>600</width>
 				<height>20</height>
-				<align>left</align>
+				<align>center</align>
 				<itemgap>10</itemgap>
 				<orientation>horizontal</orientation>
 				<control type="label">
-					<width min="25" max="840">auto</width>
+					<width min="25" max="600">auto</width>
 					<height>20</height>
 					<font>METF_PlotTextMedium</font>
 					<textcolor>LowerText</textcolor>
@@ -310,7 +305,7 @@
 					<visible>!IsEmpty(ListItem.PictureFocalLen) + ![IsEmpty(ListItem.PictureAperture) + IsEmpty(ListItem.PictureFocusDist)]</visible>
 				</control>
 				<control type="label">
-					<width min="25" max="840">auto</width>
+					<width min="25" max="600">auto</width>
 					<height>20</height>
 					<font>METF_PlotTextMedium</font>
 					<textcolor>LowerText</textcolor>
@@ -326,7 +321,7 @@
 					<visible>![IsEmpty(ListItem.PictureFocalLen) + IsEmpty(ListItem.PictureAperture)] + !IsEmpty(ListItem.PictureFocusDist)</visible>
 				</control>
 				<control type="label">
-					<width min="25" max="840">auto</width>
+					<width min="25" max="600">auto</width>
 					<height>20</height>
 					<font>METF_PlotTextMedium</font>
 					<textcolor>LowerText</textcolor>
@@ -337,22 +332,13 @@
 			</control>
 			<!-- Exposure -->
 			<control type="label">
-				<width>840</width>
+				<width>600</width>
 				<height>20</height>
+				<align>center</align>
 				<font>METF_PlotTextMedium</font>
 				<textcolor>LowerText</textcolor>
 				<label>$INFO[ListItem.PictureExpTime] @ ISO $INFO[ListItem.PictureISO]</label>
 				<visible>!IsEmpty(ListItem.PictureExpTime) + !IsEmpty(ListItem.PictureISO)</visible>
-			</control>
-			<!-- Comment -->
-			<control type="textbox">
-				<width>840</width>
-				<height>65</height>
-				<align>left</align>
-				<autoscroll time="4000" delay="3000" repeat="3000">Skin.HasSetting(AutoScroll)</autoscroll>
-				<font>METF_PlotTextMedium</font>
-				<textcolor>LowerText</textcolor>
-				<label>$INFO[ListItem.PictureCaption]</label>
 			</control>
 		</control>
 	</include>
@@ -1617,7 +1603,7 @@
 	</include>
 	<!-- Genre Descriptions -->
 	<include name="GenreDescriptions">
-		<control type="group">
+		<control type="group" id="9903">
 			<include>Animation_FadedByMenu</include>
 			<include>Animation_OpenCloseFade</include>
 			<include>Animation_HiddenByInfo</include>

--- a/720p/Includes_MediaFlags.xml
+++ b/720p/Includes_MediaFlags.xml
@@ -1,215 +1,210 @@
 ﻿<includes>
 	<include name="MediaInfo">
-		<control type="group">
-			<!--
-			<visible>!ListItem.IsFolder</visible>
-			-->
+		<control type="group" id="9901">
+			<visible>!IsEmpty(ListItem.Title) + !SubString(Container.FolderPath,plugin)</visible>
+			<visible>![Container.Content(movies) + IsEmpty(listitem.Genre) + IsEmpty(ListItem.VideoResolution)]</visible>
 			<control type="group">
-				<visible>!IsEmpty(ListItem.Title) + !SubString(Container.FolderPath,plugin)</visible>
-				<visible>![Container.Content(movies) + IsEmpty(listitem.Genre) + IsEmpty(ListItem.VideoResolution)]</visible>
+				<posx>3</posx>
+				<posy>5</posy>
+				<visible>[Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)]</visible>
+				<!-- MPAA Flags -->
 				<control type="group">
-					<posx>3</posx>
-					<posy>5</posy>
-					<visible>[Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)]</visible>
-					<!-- MPAA Flags -->
-					<control type="group">
-						<posx>28</posx>
-						<posy>560</posy>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/NoRating.png</texture>
-							<visible>IsEmpty(listitem.mpaa)</visible>
-						</control>
-						<!-- US/MPAA -->
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/mpaa_r.png</texture>
-							<visible>substring(listitem.mpaa,Rated R,Left)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/mpaa_pg13.png</texture>
-							<visible>substring(listitem.mpaa,Rated PG-13,Left)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/mpaa_pg.png</texture>
-							<visible>substring(listitem.mpaa,Rated PG,Left) + !substring(listitem.mpaa,Rated PG-13,Left)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/mpaa_nc17.png</texture>
-							<visible>substring(listitem.mpaa,Rated NC,Left)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/mpaa_general.png</texture>
-							<visible>substring(listitem.mpaa,Rated G,Left)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>$INFO[listitem.mpaa,flags/Rating/,.png]</texture>
-							<visible>substring(listitem.mpaa,TV-)</visible>
-						</control>
-						<!-- Germany -->
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/germany_0.png</texture>
-							<visible>substring(listitem.mpaa,Germany:0)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>t>
-							<texture>flags/Rating/germany_6.png</texture>
-							<visible>substring(listitem.mpaa,Germany:6)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/germany_12.png</texture>
-							<visible>substring(listitem.mpaa,Germany:12)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/germany_16.png</texture>
-							<visible>substring(listitem.mpaa,Germany:16)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/germany_18.png</texture>
-							<visible>substring(listitem.mpaa,Germany:18)</visible>
-						</control>
-						<!-- Australia -->
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/australia_r.png</texture>
-							<visible>substring(listitem.mpaa,Australia:R)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/australia_m.png</texture>
-							<visible>substring(listitem.mpaa,Australia:M) + !substring(listitem.mpaa,Australia:MA)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/australia_ma.png</texture>
-							<visible>substring(listitem.mpaa,Australia:MA)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/australia_pg.png</texture>
-							<visible>substring(listitem.mpaa,Australia:PG)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/australia_g.png</texture>
-							<visible>substring(listitem.mpaa,Australia:G)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/australia_e.png</texture>
-							<visible>substring(listitem.mpaa,Australia:E)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/australia_x.png</texture>
-							<visible>substring(listitem.mpaa,Australia:X)</visible>
-						</control>
-						<!-- United Kingdom -->
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/bbfc_u.png</texture>
-							<visible>substring(listitem.mpaa,UK:U)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/bbfc_pg.png</texture>
-							<visible>substring(listitem.mpaa,UK:PG)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/bbfc_12.png</texture>
-							<visible>substring(listitem.mpaa,UK:12)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/bbfc_12a.png</texture>
-							<visible>substring(listitem.mpaa,UK:12A)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/bbfc_15.png</texture>
-							<visible>substring(listitem.mpaa,UK:15)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/bbfc_18.png</texture>
-							<visible>substring(listitem.mpaa,UK:18)</visible>
-						</control>
-						<control type="image">
-							<include>MediaFlagsVarsMPAA</include>
-							<texture>flags/Rating/bbfc_r18.png</texture>
-							<visible>substring(listitem.mpaa,UK:X)</visible>
-						</control>
-						<control type="image">
-							<posx>-10</posx>
-							<posy>-4</posy>
-							<width>66</width>
-							<height>58</height>
-							<texture>flags/flag_framesquare.png</texture>
-							<colordiffuse>MediaFlagBoxDiffuse</colordiffuse>
-						</control>
+					<posx>28</posx>
+					<posy>560</posy>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/NoRating.png</texture>
+						<visible>IsEmpty(listitem.mpaa)</visible>
 					</control>
-					<!-- Rating Stars -->
-					<control type="group">
-						<posx>91</posx>
-						<posy>560</posy>
-						<visible>!IsEmpty(ListItem.Rating)</visible>
-						<control type="image">
-							<posx>2</posx>
-							<posy>4</posy>
-							<width>42</width>
-							<height>42</height>
-							<texture>Star.png</texture>
-							<colordiffuse>RatingStarDiffuse</colordiffuse>
-						</control>
-						<control type="label">
-							<posx>-2</posx>
-							<posy>0</posy>
-							<width>50</width>
-							<height>50</height>
-							<align>center</align>
-							<aligny>center</aligny>
-							<info>ListItem.Rating</info>
-							<textcolor>MediaFlagDiffuse</textcolor>
-							<font>METF_StarRating</font>
-						</control>
-						<control type="image">
-							<posx>-10</posx>
-							<posy>-4</posy>
-							<width>66</width>
-							<height>58</height>
-							<texture>flags/flag_framesquare.png</texture>
-							<colordiffuse>MediaFlagBoxDiffuse</colordiffuse>
-						</control>
+					<!-- US/MPAA -->
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/mpaa_r.png</texture>
+						<visible>substring(listitem.mpaa,Rated R,Left)</visible>
 					</control>
-					<!-- Studios -->
-					<control type="group">
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/mpaa_pg13.png</texture>
+						<visible>substring(listitem.mpaa,Rated PG-13,Left)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/mpaa_pg.png</texture>
+						<visible>substring(listitem.mpaa,Rated PG,Left) + !substring(listitem.mpaa,Rated PG-13,Left)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/mpaa_nc17.png</texture>
+						<visible>substring(listitem.mpaa,Rated NC,Left)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/mpaa_general.png</texture>
+						<visible>substring(listitem.mpaa,Rated G,Left)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>$INFO[listitem.mpaa,flags/Rating/,.png]</texture>
+						<visible>substring(listitem.mpaa,TV-)</visible>
+					</control>
+					<!-- Germany -->
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/germany_0.png</texture>
+						<visible>substring(listitem.mpaa,Germany:0)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>t>
+						<texture>flags/Rating/germany_6.png</texture>
+						<visible>substring(listitem.mpaa,Germany:6)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/germany_12.png</texture>
+						<visible>substring(listitem.mpaa,Germany:12)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/germany_16.png</texture>
+						<visible>substring(listitem.mpaa,Germany:16)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/germany_18.png</texture>
+						<visible>substring(listitem.mpaa,Germany:18)</visible>
+					</control>
+					<!-- Australia -->
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/australia_r.png</texture>
+						<visible>substring(listitem.mpaa,Australia:R)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/australia_m.png</texture>
+						<visible>substring(listitem.mpaa,Australia:M) + !substring(listitem.mpaa,Australia:MA)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/australia_ma.png</texture>
+						<visible>substring(listitem.mpaa,Australia:MA)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/australia_pg.png</texture>
+						<visible>substring(listitem.mpaa,Australia:PG)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/australia_g.png</texture>
+						<visible>substring(listitem.mpaa,Australia:G)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/australia_e.png</texture>
+						<visible>substring(listitem.mpaa,Australia:E)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/australia_x.png</texture>
+						<visible>substring(listitem.mpaa,Australia:X)</visible>
+					</control>
+					<!-- United Kingdom -->
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/bbfc_u.png</texture>
+						<visible>substring(listitem.mpaa,UK:U)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/bbfc_pg.png</texture>
+						<visible>substring(listitem.mpaa,UK:PG)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/bbfc_12.png</texture>
+						<visible>substring(listitem.mpaa,UK:12)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/bbfc_12a.png</texture>
+						<visible>substring(listitem.mpaa,UK:12A)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/bbfc_15.png</texture>
+						<visible>substring(listitem.mpaa,UK:15)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/bbfc_18.png</texture>
+						<visible>substring(listitem.mpaa,UK:18)</visible>
+					</control>
+					<control type="image">
+						<include>MediaFlagsVarsMPAA</include>
+						<texture>flags/Rating/bbfc_r18.png</texture>
+						<visible>substring(listitem.mpaa,UK:X)</visible>
+					</control>
+					<control type="image">
+						<posx>-10</posx>
+						<posy>-4</posy>
+						<width>66</width>
+						<height>58</height>
+						<texture>flags/flag_framesquare.png</texture>
+						<colordiffuse>MediaFlagBoxDiffuse</colordiffuse>
+					</control>
+				</control>
+				<!-- Rating Stars -->
+				<control type="group">
+					<posx>91</posx>
+					<posy>560</posy>
+					<visible>!IsEmpty(ListItem.Rating)</visible>
+					<control type="image">
 						<posx>2</posx>
-						<posy>622</posy>
-						<visible>!SubString(Container.FolderPath,plugin)</visible>
-						<control type="image">
-							<height>70</height>
-							<aspectratio aligny="center">keep</aspectratio>
-							<colordiffuse>MediaFlagDiffuse</colordiffuse>
-							<texture fallback="flags/default.png">special://skin/extras/studios/$INFO[ListItem.Studio,,.png]</texture>
-						</control>
-						<control type="image">
-							<posx>10</posx>
-							<posy>-9</posy>
-							<width>140</width>
-							<height>90</height>
-							<texture>flags/flag_frame.png</texture>
-							<colordiffuse>MediaFlagBoxDiffuse</colordiffuse>
-						</control>
+						<posy>4</posy>
+						<width>42</width>
+						<height>42</height>
+						<texture>Star.png</texture>
+						<colordiffuse>RatingStarDiffuse</colordiffuse>
+					</control>
+					<control type="label">
+						<posx>-2</posx>
+						<posy>0</posy>
+						<width>50</width>
+						<height>50</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<info>ListItem.Rating</info>
+						<textcolor>MediaFlagDiffuse</textcolor>
+						<font>METF_StarRating</font>
+					</control>
+					<control type="image">
+						<posx>-10</posx>
+						<posy>-4</posy>
+						<width>66</width>
+						<height>58</height>
+						<texture>flags/flag_framesquare.png</texture>
+						<colordiffuse>MediaFlagBoxDiffuse</colordiffuse>
+					</control>
+				</control>
+				<!-- Studios -->
+				<control type="group">
+					<posx>2</posx>
+					<posy>622</posy>
+					<visible>!SubString(Container.FolderPath,plugin)</visible>
+					<control type="image">
+						<height>70</height>
+						<aspectratio aligny="center">keep</aspectratio>
+						<colordiffuse>MediaFlagDiffuse</colordiffuse>
+						<texture fallback="flags/default.png">special://skin/extras/studios/$INFO[ListItem.Studio,,.png]</texture>
+					</control>
+					<control type="image">
+						<posx>10</posx>
+						<posy>-9</posy>
+						<width>140</width>
+						<height>90</height>
+						<texture>flags/flag_frame.png</texture>
+						<colordiffuse>MediaFlagBoxDiffuse</colordiffuse>
 					</control>
 				</control>
 			</control>

--- a/720p/Includes_MediaFlags2.xml
+++ b/720p/Includes_MediaFlags2.xml
@@ -1,7 +1,7 @@
 ﻿<includes>
 	<include name="MediaInfo2">
 		<!-- Additional Media Flags -->
-		<control type="group">
+		<control type="group" id="9902">
 			<posx>171</posx>
 			<posy>3</posy>
 			<include>Animation_FadedByMenu</include>

--- a/720p/Includes_MusicOverlay.xml
+++ b/720p/Includes_MusicOverlay.xml
@@ -1,7 +1,7 @@
 ﻿<includes>
 	<include name="GlobalMusic">
 		<control type="group">
-			<visible>Player.HasAudio + !Window.IsActive(visualisation) + !Window.IsActive(karaoke) + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True)</visible>
+			<visible>Player.HasAudio + !Window.IsActive(visualisation) + !Window.IsActive(karaoke) + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True) + ![Control.IsVisible(9900) | Control.IsVisible(9901) | Control.IsVisible(9902) | Control.IsVisible(9903)]</visible>
 			<control type="group">
 				<posx>20</posx>
 				<posy>560</posy>
@@ -30,7 +30,6 @@
 				<animation effect="slide" start="0,0" end="-186,0" time="600" condition="Window.IsActive(filemanager) | Window.IsActive(musicplaylisteditor)">Conditional</animation>
 				<visible>[![Container.Content(albums) | Container.Content(artists)] | [IsEmpty(ListItem.Property(Album_Description)) + IsEmpty(ListItem.Property(Artist_Description))]] + [!Window.IsActive(home) | [!Skin.HasSetting(Home2) + [![Container(9000).Hasfocus(4) | Container(9000).Hasfocus(5)] + [Skin.HasSetting(ShowRecentlyAdded) | Skin.HasSetting(ShowRandomItems)]]] | [Skin.HasSetting(Home2) + ![Container(9000).HasFocus(1) | Container(9000).HasFocus(2) | Container(9000).HasFocus(3) | Container(9000).HasFocus(4) | Container(9000).HasFocus(5) | Container(9000).HasFocus(8) | Container(9000).HasFocus(9) | Container(9000).HasFocus(11)]]]</visible>
 				<control type="group">
-					<visible>!Window.IsActive(videolibrary)</visible>
 					<control type="fadelabel">
 						<posx>160</posx>
 						<posy>92</posy>

--- a/720p/MyPics.xml
+++ b/720p/MyPics.xml
@@ -169,6 +169,7 @@
 		</control>
 		<include>Global_Time</include>
 		<include>Global_Heading</include>
+		<include>GlobalMusic</include>
 		<include condition="Skin.HasSetting(DebugGrid)">Object_DebugGrid</include>
 		<include condition="Skin.HasSetting(DebugMode)">Debug</include>
 	</controls>

--- a/720p/MyPrograms.xml
+++ b/720p/MyPrograms.xml
@@ -97,6 +97,7 @@
 		</control>
 		<include>Global_Time</include>
 		<include>Global_Heading</include>
+		<include>GlobalMusic</include>
 		<include condition="Skin.HasSetting(DebugGrid)">Object_DebugGrid</include>
 		<include condition="Skin.HasSetting(DebugMode)">Debug</include>
 	</controls>

--- a/720p/MyVideo.xml
+++ b/720p/MyVideo.xml
@@ -161,6 +161,7 @@
 		</control>
 		<include>Global_Time</include>
 		<include>Global_Heading</include>
+		<include>GlobalMusic</include>
 		<include condition="Skin.HasSetting(DebugGrid)">Object_DebugGrid</include>
 		<include condition="Skin.HasSetting(DebugMode)">Debug</include>
 	</controls>

--- a/720p/MyVideoNav.xml
+++ b/720p/MyVideoNav.xml
@@ -259,6 +259,7 @@
 		</control>
 		<include>Global_Time</include>
 		<include>Global_Heading</include>
+		<include>GlobalMusic</include>
 		<include>NextAiredInfo</include>
 		<include condition="Skin.HasSetting(DebugGrid)">Object_DebugGrid</include>
 		<include condition="Skin.HasSetting(DebugMode)">Debug</include>

--- a/720p/Settings.xml
+++ b/720p/Settings.xml
@@ -3,7 +3,6 @@
 	<allowoverlay>yes</allowoverlay>
 	<controls>
 		<include>Global_Background</include>
-		<include>GlobalMusic</include>
 		<control type="label">
 			<posx>30</posx>
 			<posy>10</posy>
@@ -308,6 +307,7 @@
 			</control>
 		</control>
 		<include>Global_Time</include>
+		<include>GlobalMusic</include>
 		<include condition="Skin.HasSetting(DebugGrid)">Object_DebugGrid</include>
 		<include condition="Skin.HasSetting(DebugMode)">Debug</include>
 	</controls>

--- a/720p/SettingsCategory.xml
+++ b/720p/SettingsCategory.xml
@@ -3,7 +3,6 @@
 	<allowoverlay>yes</allowoverlay>
 	<controls>
 		<include>Global_Background</include>
-		<include>GlobalMusic</include>		
 		<control type="group">
 			<animation type="Conditional" condition="Window.IsActive(locksettings) | Window.IsActive(yesnodialog)">
 				<effect type="zoom" time="600" center="640,360" start="100" end="50" tween="cubic" easing="inout" />
@@ -74,6 +73,7 @@
 		</control>
 		<include>Global_ContextFilter</include>
 		<include>Global_Time</include>
+		<include>GlobalMusic</include>
 		<include>Setting_Heading</include>
 		<include condition="Skin.HasSetting(DebugGrid)">Object_DebugGrid</include>
 		<include condition="Skin.HasSetting(DebugMode)">Debug</include>

--- a/720p/SettingsProfile.xml
+++ b/720p/SettingsProfile.xml
@@ -3,7 +3,6 @@
 	<allowoverlay>yes</allowoverlay>
 	<controls>
 		<include>Global_Background</include>
-		<include>GlobalMusic</include>
 		<control type="group">
 			<posy>-60</posy>
 			<include>Animation_OpenCloseFade</include>


### PR DESCRIPTION
Instead of looking at which library the user is in, assign IDs to the groups that put info on the bottom of the screen and hide the music overlay only when those are visible.

This shows the CD Art much more often than before :)
