### PR TITLE
Limit Update Library in video submenus.

### DIFF
--- a/720p/Includes_Home1.xml
+++ b/720p/Includes_Home1.xml
@@ -437,6 +437,7 @@
 					<include>Submenu_Button</include>
 					<label>$LOCALIZE[653]</label>
 					<onclick>UpdateLibrary(video)</onclick>
+					<visible>Skin.HasSetting(NoVideos)</visible>
 				</control>
 			</control>
 			<!-- TVShows Submenu -->
@@ -485,6 +486,7 @@
 					<include>Submenu_Button</include>
 					<label>$LOCALIZE[653]</label>
 					<onclick>UpdateLibrary(video)</onclick>
+					<visible>Skin.HasSetting(NoVideos)</visible>
 				</control>
 			</control>
 			<!-- Videos Submenu -->

--- a/720p/Includes_Home2.xml
+++ b/720p/Includes_Home2.xml
@@ -327,6 +327,7 @@
 					<include>Submenu_Button2</include>
 					<label>$LOCALIZE[653]</label>
 					<onclick>UpdateLibrary(video)</onclick>
+					<visible>Skin.HasSetting(NoVideos)</visible>
 				</control>
 			</control>
 			<!-- TVShows Submenu -->
@@ -375,6 +376,7 @@
 					<include>Submenu_Button2</include>
 					<label>$LOCALIZE[653]</label>
 					<onclick>UpdateLibrary(video)</onclick>
+					<visible>Skin.HasSetting(NoVideos)</visible>
 				</control>
 			</control>
 			<!-- Videos Submenu -->


### PR DESCRIPTION
If Videos is shown on the Home screen, don't show the Update Library link in the Movies and TV Shows submenus.
