### PR TITLE
PVR Fix : Contest wasn't saved/restored correctly

### DIFF
--- a/720p/Includes_Home1.xml
+++ b/720p/Includes_Home1.xml
@@ -441,7 +441,7 @@
 					<label>$LOCALIZE[31601]</label>
 					<icon>special://skin/extras/home1/tv.jpg</icon>
 					<thumb>$INFO[Skin.String(CustomLiveTV)]</thumb>
-					<onclick>ActivateWindow(TV)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
 					<visible>Skin.HasSetting(LiveTV)</visible>
 				</item>
 				<item id="3">
@@ -1065,22 +1065,30 @@
 				<control type="button" id="92001">
 					<include>Submenu_Button</include>
 					<label>$LOCALIZE[19023]</label>
-					<onclick>ActivateWindowAndFocus(PVR, 32,0, 11,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(32)</onclick>
+					<onclick>Setfocus(11)</onclick>
 				</control>
 				<control type="button" id="92002">
 					<include>Submenu_Button</include>
 					<label>$LOCALIZE[19069]</label>
-					<onclick>ActivateWindowAndFocus(PVR, 31,0, 10,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(31)</onclick>
+					<onclick>Setfocus(10)</onclick>
 				</control>
 				<control type="button" id="92003">
 					<include>Submenu_Button</include>
 					<label>$LOCALIZE[19163]</label>
-					<onclick>ActivateWindowAndFocus(PVR, 34,0, 13,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(34)</onclick>
+					<onclick>Setfocus(13)</onclick>
 				</control>
 				<control type="button" id="92004">
 					<include>Submenu_Button</include>
 					<label>$LOCALIZE[19040]</label>
-					<onclick>ActivateWindowAndFocus(MyPVR, 35,0, 14,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(35)</onclick>
+					<onclick>Setfocus(14)</onclick>
 				</control>
 			</control>
 			<!-- Music Submenu -->

--- a/720p/Includes_Home2.xml
+++ b/720p/Includes_Home2.xml
@@ -367,7 +367,7 @@
 					<description>Live TV</description>
 					<label>$LOCALIZE[31601]</label>
 					<icon>special://skin/extras/home2/icon_tv.png</icon>
-					<onclick>ActivateWindow(TV)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
 					<visible>Skin.HasSetting(LiveTV)</visible>
 				</item>
 				<item id="3">
@@ -956,22 +956,30 @@
 				<control type="button" id="92001">
 					<include>Submenu_Button2</include>
 					<label>$LOCALIZE[19023]</label>
-					<onclick>ActivateWindowAndFocus(PVR, 32,0, 11,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(32)</onclick>
+					<onclick>Setfocus(11)</onclick>
 				</control>
 				<control type="button" id="92002">
 					<include>Submenu_Button2</include>
 					<label>$LOCALIZE[19069]</label>
-					<onclick>ActivateWindowAndFocus(PVR, 31,0, 10,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(31)</onclick>
+					<onclick>Setfocus(10)</onclick>
 				</control>
 				<control type="button" id="92003">
 					<include>Submenu_Button2</include>
 					<label>$LOCALIZE[19163]</label>
-					<onclick>ActivateWindowAndFocus(PVR, 34,0, 13,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(34)</onclick>
+					<onclick>Setfocus(13)</onclick>
 				</control>
 				<control type="button" id="92004">
 					<include>Submenu_Button2</include>
 					<label>$LOCALIZE[19040]</label>
-					<onclick>ActivateWindowAndFocus(MyPVR, 35,0, 14,0)</onclick>
+					<onclick>ActivateWindow(PVR)</onclick>
+					<onclick>Setfocus(35)</onclick>
+					<onclick>Setfocus(14)</onclick>
 				</control>
 			</control>
 			<!-- Music Submenu -->

--- a/720p/MyPVR.xml
+++ b/720p/MyPVR.xml
@@ -1,5 +1,5 @@
 <window id="600">
-	<defaultcontrol always="true">32</defaultcontrol>
+	<defaultcontrol always="false">32</defaultcontrol>
 	<allowoverlay>yes</allowoverlay>
 	<controls>
 		<include>Global_Background</include>


### PR DESCRIPTION
It is a fix for the problem seen by grywnn. (Please see it here : http://forum.xbmc.org/showthread.php?tid=135611&pid=1180849#pid1180849)

Changes :
- ActivateWindowAndFocus changed to ActivateWindows + SetFocus() to avoid display problems. (I don't see why...)
- Always set to false for defaultcontrol in MyPVR.xml
- Harmonize PVR window name.
