### PR TITLE
Fix for Issue #81 (mouse movement triggers popup)

### DIFF
--- a/720p/Includes_Animations.xml
+++ b/720p/Includes_Animations.xml
@@ -36,7 +36,7 @@
 	</include>
 	<include name="Animation_NavMenu">
 	<animation type="Conditional" condition="!ControlGroup(7000).HasFocus()">
-		<effect type="zoom" start="100" end="70" center="auto" tween="back" easing="in" time="400" />
+		<effect type="zoom" start="100" end="0" center="auto" tween="back" easing="in" time="400" />
 		<effect type="fade" start="100" end="0" time="400" />
 	</animation>
 	</include>


### PR DESCRIPTION
This tiny change dramatically improves the skin's behavior with a mouse & keyboard.

A keyboard is still required for a few functions - notably popup menus and video seeking, but it's now quite usable.

Please see my detailed commit notes here: https://github.com/ryankevans/Metropolis/commit/6f7c140
