### PR TITLE
Fanart Fullscreen view for videos

### DIFF
--- a/720p/Includes.xml
+++ b/720p/Includes.xml
@@ -16,6 +16,7 @@
 	<include file="Viewtype_Fanart.xml" />			<!-- 504 -->
 	<include file="Viewtype_FanartBanner.xml" />		<!-- 508 -->
 	<include file="Viewtype_FanartList.xml" />		<!-- 509 -->
+	<include file="Viewtype_FanartWall.xml" />		<!-- 513 -->
 	<include file="Viewtype_List.xml" />			<!-- 55  -->
 	<include file="Viewtype_Gallery.xml" />			<!-- 54  -->
 	<include file="Viewtype_Gallery_Fanart.xml" />		<!-- 59  -->
@@ -465,6 +466,7 @@
 	<include name="Global_VideoPlot">
 		<control type="group" id="9900">
 			<visible>!Skin.HasSetting(Hide_Plot) + [Container.Content(Movies) | Container.Content(TVShows) | Container.Content(Seasons) | Container.Content(Episodes) | Container.Content(MusicVideos) | SubString(Container.FolderPath,plugin)]</visible>
+			<visible>!Control.IsVisible(513)</visible> <!-- Do not display plot for FanartWall view, we need the space to display the title -->
 			<include>PlotBox</include>
 		</control>
 	</include>

--- a/720p/MyVideoNav.xml
+++ b/720p/MyVideoNav.xml
@@ -2,7 +2,7 @@
 <window id="25">
 	<onload condition="Skin.HasSetting(TvTunes) + !SubString(Window(Videos).Property(CinemaExperienceRunning),True)">RunScript(script.tvtunes,backend=True)</onload>
 	<onload condition="Skin.HasSetting(NextAired) + !SubString(Window(Videos).Property(CinemaExperienceRunning),True) + [Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)]">RunScript(script.tv.show.next.aired,backend=True)</onload>
-	<views>55,905,54,58,59,559,53,57,551,550,504,509,511,508,510,52,56,512,501</views>
+	<views>55,905,54,58,59,559,53,57,551,550,504,513,509,511,508,510,52,56,512,501</views>
 	<defaultcontrol always="true">55</defaultcontrol>
 	<allowoverlay>yes</allowoverlay>
 	<controls>
@@ -29,6 +29,7 @@
 		<include>Viewtype_Fanart</include>			<!-- 504 -->
 		<include>Viewtype_FanartList</include>			<!-- 509 -->
 		<include>Viewtype_FanartBanner</include>		<!-- 508 -->
+		<include>Viewtype_FanartWall</include>			<!-- 513 -->
 		<include>Viewtype_Banner</include>			<!-- 511 -->
 		<include>Viewtype_BannerPoster</include>		<!-- 510 -->
 		<include>Viewtype_Gallery</include>			<!-- 54 -->

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -3271,7 +3271,7 @@
 					<control type="radiobutton" id="612">
 						<description>Fanart Wall</description>
 						<include>SettingsLabel</include>
-						<label>$LOCALIZE[31441] Fanart Wall</label>
+						<label>$LOCALIZE[31441] Fanart Wall</label> <!-- TODO Needs a language resource instead -->
 						<onclick>Skin.ToggleSetting(NoViewFanartWall)</onclick>
 						<selected>Skin.HasSetting(NoViewFanartWall)</selected>
 					</control>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -3267,8 +3267,16 @@
 						<onclick>Skin.ToggleSetting(NoViewFanartList)</onclick>
 						<selected>Skin.HasSetting(NoViewFanartList)</selected>
 					</control>
-					<!-- View 511 -->
+					<!-- View 513 -->
 					<control type="radiobutton" id="612">
+						<description>Fanart Wall</description>
+						<include>SettingsLabel</include>
+						<label>$LOCALIZE[31441] Fanart Wall</label>
+						<onclick>Skin.ToggleSetting(NoViewFanartWall)</onclick>
+						<selected>Skin.HasSetting(NoViewFanartWall)</selected>
+					</control>
+					<!-- View 511 -->
+					<control type="radiobutton" id="613">
 						<description>Banner</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31286]</label>
@@ -3276,7 +3284,7 @@
 						<selected>Skin.HasSetting(NoViewBanner)</selected>
 					</control>
 					<!-- View 508 -->
-					<control type="radiobutton" id="613">
+					<control type="radiobutton" id="614">
 						<description>Banner Fanart</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31442]</label>
@@ -3284,7 +3292,7 @@
 						<selected>Skin.HasSetting(NoViewBannerFanart)</selected>
 					</control>
 					<!-- View 510 -->
-					<control type="radiobutton" id="614">
+					<control type="radiobutton" id="615">
 						<description>Banner Poster</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31439]</label>
@@ -3292,7 +3300,7 @@
 						<selected>Skin.HasSetting(NoViewBannerPoster)</selected>
 					</control>
 					<!-- View 52 -->
-					<control type="radiobutton" id="615">
+					<control type="radiobutton" id="616">
 						<description>Landscape</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31291]</label>
@@ -3300,7 +3308,7 @@
 						<selected>Skin.HasSetting(NoViewLandscape)</selected>
 					</control>
 					<!-- View 56 -->
-					<control type="radiobutton" id="616">
+					<control type="radiobutton" id="617">
 						<description>Logo</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31054]</label>
@@ -3308,7 +3316,7 @@
 						<selected>Skin.HasSetting(NoViewLogo)</selected>
 					</control>
 					<!-- View 512 -->
-					<control type="radiobutton" id="617">
+					<control type="radiobutton" id="618">
 						<description>Coverflow</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[33031]</label>
@@ -3316,7 +3324,7 @@
 						<selected>Skin.HasSetting(NoViewCoverflow)</selected>
 					</control>
 					<!-- View 500 -->
-					<control type="radiobutton" id="618">
+					<control type="radiobutton" id="619">
 						<description>Picture Grid</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31293]</label>
@@ -3324,7 +3332,7 @@
 						<selected>Skin.HasSetting(NoViewPictureGrid)</selected>
 					</control>
 					<!-- View 559 -->
-					<control type="radiobutton" id="619">
+					<control type="radiobutton" id="620">
 						<description>Panel Square</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31298]</label>
@@ -3332,7 +3340,7 @@
 						<selected>Skin.HasSetting(NoViewPanelSquare)</selected>
 					</control>
 					<!-- View 501 -->
-					<control type="radiobutton" id="620">
+					<control type="radiobutton" id="621">
 						<description>Tall Genre</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31416]</label>
@@ -3340,7 +3348,7 @@
 						<selected>Skin.HasSetting(NoViewTallGenre)</selected>
 					</control>
 					<!-- View 950 -->
-					<control type="radiobutton" id="621">
+					<control type="radiobutton" id="622">
 						<description>Games</description>
 						<include>SettingsLabel</include>
 						<label>$LOCALIZE[31441] $LOCALIZE[31460]</label>

--- a/720p/Viewtype_FanartWall.xml
+++ b/720p/Viewtype_FanartWall.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<includes>
+	<include name="VideoFanartWall">
+		<itemlayout height="720" width="1280">
+			<control type="image">
+				<include>Dimensions_Fullscreen</include>
+				<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
+			</control>
+		</itemlayout>
+		<focusedlayout height="720" width="1280">
+			<control type="image">
+				<include>Dimensions_Fullscreen</include>
+				<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
+			</control>
+		</focusedlayout>
+	</include>
+  
+	<include name="Viewtype_FanartWall">
+		<control type="group">
+			<visible>Control.IsVisible(513)</visible>
+			<!-- Browser -->
+			<control type="wraplist" id="513">
+				<posx>0</posx>
+				<posy>0</posy>
+				<height>540</height>
+				<include condition="!Skin.HasSetting(ViewLockdown)">OnUp7000</include>
+				<ondown>60</ondown>
+				<onleft>513</onleft>
+				<onright>513</onright>
+				<viewtype label="20445">bigwrap</viewtype>
+				<orientation>horizontal</orientation>
+				<scrolltime>200</scrolltime>
+				<preloaditems>2</preloaditems>
+				<pagecontrol>60</pagecontrol>
+				<include>Animation_FadedByMenu</include>
+				<include>Animation_OpenCloseFade</include>
+				<include>Animation_HiddenByInfo</include>
+				<visible>!Skin.HasSetting(NoViewFanartWall)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+
+				<include condition="Window.IsVisible(videolibrary)">VideoFanartWall</include>
+			</control>
+			<!-- Browser label and flags -->
+			<control type="group">
+				<posx>40</posx>
+				
+				<!-- Position depends on whether plot is displayed or not: Skin.HasSetting(Hide_Plot) -->
+				<posy>560</posy>
+				<include>Animation_FadedByMenu</include>
+				<include>Animation_HiddenByInfo</include>
+				<include>Animation_OpenCloseFade</include>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+				
+				<!-- Title (prefer clearlogo, then clearart, then label) -->
+				<control type="image">
+				  <posx>0</posx>
+				  <posy>0</posy>
+				  <width>310</width>
+				  <height>120</height>
+				  <aspectratio align="left" aligny="top">keep</aspectratio>
+				  <texture background="true">$INFO[ListItem.Art(clearlogo)]</texture>
+				  <visible>!IsEmpty(ListItem.Art(clearlogo))</visible>
+				</control>
+				<control type="image">
+				  <posx>0</posx>
+				  <posy>0</posy>
+				  <width>310</width>
+				  <height>120</height>
+				  <aspectratio align="left" aligny="top">keep</aspectratio>
+				  <texture background="true">$INFO[ListItem.Art(clearart)]</texture>
+				  <visible>IsEmpty(ListItem.Art(clearlogo)) + !IsEmpty(ListItem.Art(clearart))</visible>
+				</control>
+				<control type="fadelabel">
+				  <posx>0</posx>
+				  <posy>0</posy>
+				  <width>1200</width>
+				  <height>50</height>
+				  <align>left</align>
+				  <aligny>top</aligny>
+				  <scrollout>false</scrollout>
+				  <pauseatend>600</pauseatend>
+				  <scrollspeed>20</scrollspeed>
+				  <font>METF_TitleTextLarge</font>
+				  <textcolor>TitleText</textcolor>
+				  <label>$INFO[ListItem.Label]</label>
+				  <visible>IsEmpty(ListItem.Art(clearlogo)) + IsEmpty(ListItem.Art(clearart))</visible>
+				</control>
+				<!-- Genre -->
+				<control type="label">
+					<posx>200</posx>
+					<posy>80</posy>
+					<width>800</width>
+					<height>30</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>METF_MediaDetailsSmall</font>
+					<textcolor>MediaDetailsGenre</textcolor>
+					<label>$INFO[ListItem.Genre]</label>
+					<visible>!IsEmpty(ListItem.Genre)</visible>
+					<!-- visible>Container.Content(movies) | Container.Content(sets)</visible -->
+				</control>
+				<!-- Movie Sets -->
+				<control type="label">
+					<posx>200</posx>
+					<posy>80</posy>
+					<width>800</width>
+					<height>30</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>METF_MediaDetailsSmall</font>
+					<textcolor>MediaDetailsGenre</textcolor>
+					<label>$LOCALIZE[31313]</label>
+					<include>VisibleIfMovieSet</include>
+				</control>
+				
+				<!-- Display an indicater if the item has been watched already -->
+				<control type="image">
+				  <posx>860</posx>
+				  <posy>100</posy>
+				  <align>right</align>
+				  <width>32</width>
+				  <height>32</height>
+				  <fadetime>200</fadetime>
+				  <texture>$INFO[ListItem.Overlay]</texture>
+				  <colordiffuse>WatchedOverlay</colordiffuse>
+				  <animation type="Focus" reversible="false">
+				    <effect type="zoom" center="323,181" start="70" end="100" time="400" tween="back" easing="out" />
+				    <effect type="fade" start="0" end="100" time="300" />
+				  </animation>
+				  <visible>!ListItem.IsResumable + [[Container.Content(movies) | Container.Content(sets)] + !Skin.HasSetting(HideMovieWatchedOverlays)] | [![Container.Content(movies) | Container.Content(sets)] + !Skin.HasSetting(HideTVWatchedOverlays)]</visible>
+				</control>
+			</control>
+			<control type="grouplist">
+				<posx>40</posx>
+				<posy>670</posy>
+				<width>1200</width>
+				<height>30</height>
+				<align>center</align>
+				<itemgap>10</itemgap>
+				<orientation>horizontal</orientation>
+				<include>Animation_FadedByMenu</include>
+				<include>Animation_HiddenByInfo</include>
+				<include>Animation_OpenCloseFade</include>
+				<visible>Container.Content(movies) | Container.Content(tvshows)</visible>
+				<include>VisibleIfNotMovieSet</include>
+				<!-- Year -->
+				<control type="label">
+					<width min="25" max="1200">auto</width>
+					<height>30</height>
+					<aligny>center</aligny>
+					<font>METF_MediaDetailsSmall</font>
+					<textcolor>MediaDetailsYear</textcolor>
+					<label>$INFO[ListItem.Year] |</label>
+					<visible>!IsEmpty(ListItem.Year)</visible>
+				</control>
+				<!-- Bullet -->
+				<control type="image">
+					<width>8</width>
+					<height>32</height>
+					<texture>Dot.png</texture>
+					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<colordiffuse>BulletDiffuse</colordiffuse>
+					<visible>![IsEmpty(ListItem.Year) | IsEmpty(ListItem.Duration)]</visible>
+				</control>
+				<!-- Duration -->
+				<control type="label">
+					<width min="25" max="1200">auto</width>
+					<height>30</height>
+					<aligny>center</aligny>
+					<font>METF_MediaDetailsSmall</font>
+					<textcolor>MediaDetailsDuration</textcolor>
+					<label>$INFO[ListItem.Duration,, [LOWERCASE]$LOCALIZE[31299][/LOWERCASE]]</label>
+					<visible>!IsEmpty(ListItem.Duration) + !SubString(ListItem.Duration,min) + !Container.Content(tvshows)</visible>
+				</control>
+				<control type="label">
+					<width min="25" max="1200">auto</width>
+					<height>30</height>
+					<aligny>center</aligny>
+					<font>METF_MediaDetailsSmall</font>
+					<textcolor>MediaDetailsDuration</textcolor>
+					<label>$INFO[ListItem.Duration]</label>
+					<visible>!IsEmpty(ListItem.Duration) + SubString(ListItem.Duration,min) + !Container.Content(tvshows)</visible>
+				</control>
+				<!-- Bullet -->
+				<control type="image">
+					<width>8</width>
+					<height>32</height>
+					<texture>Dot.png</texture>
+					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<colordiffuse>BulletDiffuse</colordiffuse>
+					<visible>![IsEmpty(ListItem.Duration) | IsEmpty(ListItem.Property(TotalEpisodes))] + !Container.Content(tvshows)</visible>
+				</control>
+				<!-- Episode Count -->
+				<control type="label">
+					<width min="25" max="1200">auto</width>
+					<height>30</height>
+					<aligny>center</aligny>
+					<font>METF_MediaDetailsSmall</font>
+					<textcolor>MediaDetailsEpisodes</textcolor>
+					<label>$INFO[ListItem.Property(TotalEpisodes)] $LOCALIZE[20360]</label>
+					<visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
+				</control>
+				<!-- Bullet -->
+				<control type="image">
+					<width>8</width>
+					<height>32</height>
+					<texture>Dot.png</texture>
+					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<colordiffuse>BulletDiffuse</colordiffuse>
+					<visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
+				</control>
+				<!-- Unwatched Episode Count -->
+				<control type="label">
+					<width min="25" max="1200">auto</width>
+					<height>30</height>
+					<aligny>center</aligny>
+					<font>METF_MediaDetailsSmall</font>
+					<textcolor>MediaDetailsEpisodes</textcolor>
+					<label>$INFO[ListItem.Property(UnWatchedEpisodes)] $LOCALIZE[16101]</label>
+					<visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
+				</control>
+			</control>
+			<include>ScrollBar_Horizontal</include>
+		</control>
+	</include>
+</includes>

--- a/720p/Viewtype_FanartWall.xml
+++ b/720p/Viewtype_FanartWall.xml
@@ -1,226 +1,278 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
-	<include name="VideoFanartWall">
-		<itemlayout height="720" width="1280">
-			<control type="image">
-				<include>Dimensions_Fullscreen</include>
-				<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
-			</control>
-		</itemlayout>
-		<focusedlayout height="720" width="1280">
-			<control type="image">
-				<include>Dimensions_Fullscreen</include>
-				<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
-			</control>
-		</focusedlayout>
-	</include>
-  
-	<include name="Viewtype_FanartWall">
-		<control type="group">
-			<visible>Control.IsVisible(513)</visible>
-			<!-- Browser -->
-			<control type="wraplist" id="513">
-				<posx>0</posx>
-				<posy>0</posy>
-				<height>540</height>
-				<include condition="!Skin.HasSetting(ViewLockdown)">OnUp7000</include>
-				<ondown>60</ondown>
-				<onleft>513</onleft>
-				<onright>513</onright>
-				<viewtype label="20445">bigwrap</viewtype>
-				<orientation>horizontal</orientation>
-				<scrolltime>200</scrolltime>
-				<preloaditems>2</preloaditems>
-				<pagecontrol>60</pagecontrol>
-				<include>Animation_FadedByMenu</include>
-				<include>Animation_OpenCloseFade</include>
-				<include>Animation_HiddenByInfo</include>
-				<visible>!Skin.HasSetting(NoViewFanartWall)</visible>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
-
-				<include condition="Window.IsVisible(videolibrary)">VideoFanartWall</include>
-			</control>
-			<!-- Browser label and flags -->
-			<control type="group">
-				<posx>40</posx>
-				
-				<!-- Position depends on whether plot is displayed or not: Skin.HasSetting(Hide_Plot) -->
-				<posy>560</posy>
-				<include>Animation_FadedByMenu</include>
-				<include>Animation_HiddenByInfo</include>
-				<include>Animation_OpenCloseFade</include>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
-				
-				<!-- Title (prefer clearlogo, then clearart, then label) -->
-				<control type="image">
-				  <posx>0</posx>
-				  <posy>0</posy>
-				  <width>310</width>
-				  <height>120</height>
-				  <aspectratio align="left" aligny="top">keep</aspectratio>
-				  <texture background="true">$INFO[ListItem.Art(clearlogo)]</texture>
-				  <visible>!IsEmpty(ListItem.Art(clearlogo))</visible>
-				</control>
-				<control type="image">
-				  <posx>0</posx>
-				  <posy>0</posy>
-				  <width>310</width>
-				  <height>120</height>
-				  <aspectratio align="left" aligny="top">keep</aspectratio>
-				  <texture background="true">$INFO[ListItem.Art(clearart)]</texture>
-				  <visible>IsEmpty(ListItem.Art(clearlogo)) + !IsEmpty(ListItem.Art(clearart))</visible>
-				</control>
-				<control type="fadelabel">
-				  <posx>0</posx>
-				  <posy>0</posy>
-				  <width>1200</width>
-				  <height>50</height>
-				  <align>left</align>
-				  <aligny>top</aligny>
-				  <scrollout>false</scrollout>
-				  <pauseatend>600</pauseatend>
-				  <scrollspeed>20</scrollspeed>
-				  <font>METF_TitleTextLarge</font>
-				  <textcolor>TitleText</textcolor>
-				  <label>$INFO[ListItem.Label]</label>
-				  <visible>IsEmpty(ListItem.Art(clearlogo)) + IsEmpty(ListItem.Art(clearart))</visible>
-				</control>
-				<!-- Genre -->
-				<control type="label">
-					<posx>200</posx>
-					<posy>80</posy>
-					<width>800</width>
-					<height>30</height>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>METF_MediaDetailsSmall</font>
-					<textcolor>MediaDetailsGenre</textcolor>
-					<label>$INFO[ListItem.Genre]</label>
-					<visible>!IsEmpty(ListItem.Genre)</visible>
-					<!-- visible>Container.Content(movies) | Container.Content(sets)</visible -->
-				</control>
-				<!-- Movie Sets -->
-				<control type="label">
-					<posx>200</posx>
-					<posy>80</posy>
-					<width>800</width>
-					<height>30</height>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>METF_MediaDetailsSmall</font>
-					<textcolor>MediaDetailsGenre</textcolor>
-					<label>$LOCALIZE[31313]</label>
-					<include>VisibleIfMovieSet</include>
-				</control>
-				
-				<!-- Display an indicater if the item has been watched already -->
-				<control type="image">
-				  <posx>860</posx>
-				  <posy>100</posy>
-				  <align>right</align>
-				  <width>32</width>
-				  <height>32</height>
-				  <fadetime>200</fadetime>
-				  <texture>$INFO[ListItem.Overlay]</texture>
-				  <colordiffuse>WatchedOverlay</colordiffuse>
-				  <animation type="Focus" reversible="false">
-				    <effect type="zoom" center="323,181" start="70" end="100" time="400" tween="back" easing="out" />
-				    <effect type="fade" start="0" end="100" time="300" />
-				  </animation>
-				  <visible>!ListItem.IsResumable + [[Container.Content(movies) | Container.Content(sets)] + !Skin.HasSetting(HideMovieWatchedOverlays)] | [![Container.Content(movies) | Container.Content(sets)] + !Skin.HasSetting(HideTVWatchedOverlays)]</visible>
-				</control>
-			</control>
-			<control type="grouplist">
-				<posx>40</posx>
-				<posy>670</posy>
-				<width>1200</width>
-				<height>30</height>
-				<align>center</align>
-				<itemgap>10</itemgap>
-				<orientation>horizontal</orientation>
-				<include>Animation_FadedByMenu</include>
-				<include>Animation_HiddenByInfo</include>
-				<include>Animation_OpenCloseFade</include>
-				<visible>Container.Content(movies) | Container.Content(tvshows)</visible>
-				<include>VisibleIfNotMovieSet</include>
-				<!-- Year -->
-				<control type="label">
-					<width min="25" max="1200">auto</width>
-					<height>30</height>
-					<aligny>center</aligny>
-					<font>METF_MediaDetailsSmall</font>
-					<textcolor>MediaDetailsYear</textcolor>
-					<label>$INFO[ListItem.Year] |</label>
-					<visible>!IsEmpty(ListItem.Year)</visible>
-				</control>
-				<!-- Bullet -->
-				<control type="image">
-					<width>8</width>
-					<height>32</height>
-					<texture>Dot.png</texture>
-					<aspectratio align="center" aligny="center">keep</aspectratio>
-					<colordiffuse>BulletDiffuse</colordiffuse>
-					<visible>![IsEmpty(ListItem.Year) | IsEmpty(ListItem.Duration)]</visible>
-				</control>
-				<!-- Duration -->
-				<control type="label">
-					<width min="25" max="1200">auto</width>
-					<height>30</height>
-					<aligny>center</aligny>
-					<font>METF_MediaDetailsSmall</font>
-					<textcolor>MediaDetailsDuration</textcolor>
-					<label>$INFO[ListItem.Duration,, [LOWERCASE]$LOCALIZE[31299][/LOWERCASE]]</label>
-					<visible>!IsEmpty(ListItem.Duration) + !SubString(ListItem.Duration,min) + !Container.Content(tvshows)</visible>
-				</control>
-				<control type="label">
-					<width min="25" max="1200">auto</width>
-					<height>30</height>
-					<aligny>center</aligny>
-					<font>METF_MediaDetailsSmall</font>
-					<textcolor>MediaDetailsDuration</textcolor>
-					<label>$INFO[ListItem.Duration]</label>
-					<visible>!IsEmpty(ListItem.Duration) + SubString(ListItem.Duration,min) + !Container.Content(tvshows)</visible>
-				</control>
-				<!-- Bullet -->
-				<control type="image">
-					<width>8</width>
-					<height>32</height>
-					<texture>Dot.png</texture>
-					<aspectratio align="center" aligny="center">keep</aspectratio>
-					<colordiffuse>BulletDiffuse</colordiffuse>
-					<visible>![IsEmpty(ListItem.Duration) | IsEmpty(ListItem.Property(TotalEpisodes))] + !Container.Content(tvshows)</visible>
-				</control>
-				<!-- Episode Count -->
-				<control type="label">
-					<width min="25" max="1200">auto</width>
-					<height>30</height>
-					<aligny>center</aligny>
-					<font>METF_MediaDetailsSmall</font>
-					<textcolor>MediaDetailsEpisodes</textcolor>
-					<label>$INFO[ListItem.Property(TotalEpisodes)] $LOCALIZE[20360]</label>
-					<visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
-				</control>
-				<!-- Bullet -->
-				<control type="image">
-					<width>8</width>
-					<height>32</height>
-					<texture>Dot.png</texture>
-					<aspectratio align="center" aligny="center">keep</aspectratio>
-					<colordiffuse>BulletDiffuse</colordiffuse>
-					<visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
-				</control>
-				<!-- Unwatched Episode Count -->
-				<control type="label">
-					<width min="25" max="1200">auto</width>
-					<height>30</height>
-					<aligny>center</aligny>
-					<font>METF_MediaDetailsSmall</font>
-					<textcolor>MediaDetailsEpisodes</textcolor>
-					<label>$INFO[ListItem.Property(UnWatchedEpisodes)] $LOCALIZE[16101]</label>
-					<visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
-				</control>
-			</control>
-			<include>ScrollBar_Horizontal</include>
-		</control>
-	</include>
+    <include name="VideoFanartWall">
+        <itemlayout height="720" width="1280">
+            <control type="image">
+                <include>Dimensions_Fullscreen</include>
+                <texture background="true">$INFO[ListItem.Art(fanart)]</texture>
+            </control>
+        </itemlayout>
+        <focusedlayout height="720" width="1280">
+            <control type="image">
+                <include>Dimensions_Fullscreen</include>
+                <texture background="true">$INFO[ListItem.Art(fanart)]</texture>
+            </control>
+        </focusedlayout>
+    </include>
+    
+    <include name="VideoFanartWall_Info">
+        <!-- Year -->
+        <control type="label">
+            <width min="25" max="1200">auto</width>
+            <height>30</height>
+            <aligny>center</aligny>
+            <font>METF_MediaDetailsSmall</font>
+            <textcolor>MediaDetailsYear</textcolor>
+            <label>$INFO[ListItem.Year]</label>
+            <visible>!IsEmpty(ListItem.Year)</visible>
+        </control>
+        <!-- Bullet -->
+        <control type="image">
+            <width>8</width>
+            <height>32</height>
+            <texture>Dot.png</texture>
+            <aspectratio align="center" aligny="center">keep</aspectratio>
+            <colordiffuse>BulletDiffuse</colordiffuse>
+            <visible>![IsEmpty(ListItem.Year) | IsEmpty(ListItem.Duration)] | ![IsEmpty(ListItem.Year) | IsEmpty(ListItem.Property(TotalEpisodes))]</visible>
+        </control>
+        <!-- Duration -->
+        <control type="label">
+            <width min="25" max="1200">auto</width>
+            <height>30</height>
+            <aligny>center</aligny>
+            <font>METF_MediaDetailsSmall</font>
+            <textcolor>MediaDetailsDuration</textcolor>
+            <label>$INFO[ListItem.Duration,, [LOWERCASE]$LOCALIZE[31299][/LOWERCASE]]</label>
+            <visible>!IsEmpty(ListItem.Duration) + !SubString(ListItem.Duration,min) + !Container.Content(tvshows)</visible>
+        </control>
+        <control type="label">
+            <width min="25" max="1200">auto</width>
+            <height>30</height>
+            <aligny>center</aligny>
+            <font>METF_MediaDetailsSmall</font>
+            <textcolor>MediaDetailsDuration</textcolor>
+            <label>$INFO[ListItem.Duration]</label>
+            <visible>!IsEmpty(ListItem.Duration) + SubString(ListItem.Duration,min) + !Container.Content(tvshows)</visible>
+        </control>
+        <!-- Bullet -->
+        <control type="image">
+            <width>8</width>
+            <height>32</height>
+            <texture>Dot.png</texture>
+            <aspectratio align="center" aligny="center">keep</aspectratio>
+            <colordiffuse>BulletDiffuse</colordiffuse>
+            <visible>![IsEmpty(ListItem.Duration) | IsEmpty(ListItem.Property(TotalEpisodes))] + !Container.Content(tvshows)</visible>
+        </control>
+        <!-- Episode Count -->
+        <control type="label">
+            <width min="25" max="1200">auto</width>
+            <height>30</height>
+            <aligny>center</aligny>
+            <font>METF_MediaDetailsSmall</font>
+            <textcolor>MediaDetailsEpisodes</textcolor>
+            <label>$INFO[ListItem.Property(TotalEpisodes)] $LOCALIZE[20360]</label>
+            <visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
+        </control>
+        <!-- Bullet -->
+        <control type="image">
+            <width>8</width>
+            <height>32</height>
+            <texture>Dot.png</texture>
+            <aspectratio align="center" aligny="center">keep</aspectratio>
+            <colordiffuse>BulletDiffuse</colordiffuse>
+            <visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
+        </control>
+        <!-- Unwatched Episode Count -->
+        <control type="label">
+            <width min="25" max="1200">auto</width>
+            <height>30</height>
+            <aligny>center</aligny>
+            <font>METF_MediaDetailsSmall</font>
+            <textcolor>MediaDetailsEpisodes</textcolor>
+            <label>$INFO[ListItem.Property(UnWatchedEpisodes)] $LOCALIZE[16101]</label>
+            <visible>!IsEmpty(ListItem.Property(TotalEpisodes)) + Container.Content(tvshows)</visible>
+        </control>
+    </include>
+    
+    <include name="VideoFanartWall_GenreWatched">
+        <!-- Genre -->
+        <control type="label">
+            <posx>200</posx>
+            <posy>80</posy>
+            <width>800</width>
+            <height>30</height>
+            <align>center</align>
+            <aligny>center</aligny>
+            <font>METF_MediaDetailsSmall</font>
+            <textcolor>MediaDetailsGenre</textcolor>
+            <label>$INFO[ListItem.Genre]</label>
+            <visible>!IsEmpty(ListItem.Genre)</visible>
+            <!-- visible>Container.Content(movies) | Container.Content(sets)</visible -->
+        </control>
+        <!-- Movie Sets -->
+        <control type="label">
+            <posx>200</posx>
+            <posy>80</posy>
+            <width>800</width>
+            <height>30</height>
+            <align>center</align>
+            <aligny>center</aligny>
+            <font>METF_MediaDetailsSmall</font>
+            <textcolor>MediaDetailsGenre</textcolor>
+            <label>$LOCALIZE[31313]</label>
+            <include>VisibleIfMovieSet</include>
+        </control>
+        
+        <!-- Display an indicater if the item has been watched already -->
+        <control type="image">
+            <posx>860</posx>
+            <posy>100</posy>
+            <align>right</align>
+            <width>32</width>
+            <height>32</height>
+            <fadetime>200</fadetime>
+            <texture>$INFO[ListItem.Overlay]</texture>
+            <colordiffuse>WatchedOverlay</colordiffuse>
+            <animation type="Focus" reversible="false">
+                <effect type="zoom" center="323,181" start="70" end="100" time="400" tween="back" easing="out" />
+                <effect type="fade" start="0" end="100" time="300" />
+            </animation>
+            <visible>!ListItem.IsResumable + [[Container.Content(movies) | Container.Content(sets)] + !Skin.HasSetting(HideMovieWatchedOverlays)] | [![Container.Content(movies) | Container.Content(sets)] + !Skin.HasSetting(HideTVWatchedOverlays)]</visible>
+        </control>
+    </include>
+    
+    <include name="Viewtype_FanartWall">
+        <control type="group">
+            <visible>Control.IsVisible(513)</visible>
+            <!-- Browser -->
+            <control type="wraplist" id="513">
+                <posx>0</posx>
+                <posy>0</posy>
+                <height>540</height>
+                <include condition="!Skin.HasSetting(ViewLockdown)">OnUp7000</include>
+                <ondown>60</ondown>
+                <onleft>513</onleft>
+                <onright>513</onright>
+                <viewtype label="Fanart Wall">bigwrap</viewtype> <!-- TODO Needs a language resource instead -->
+                <orientation>horizontal</orientation>
+                <scrolltime>200</scrolltime>
+                <preloaditems>2</preloaditems>
+                <pagecontrol>60</pagecontrol>
+                <include>Animation_FadedByMenu</include>
+                <include>Animation_OpenCloseFade</include>
+                <include>Animation_HiddenByInfo</include>
+                <visible>!Skin.HasSetting(NoViewFanartWall)</visible>
+                <visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+                
+                <include condition="Window.IsVisible(videolibrary)">VideoFanartWall</include>
+            </control>
+            <!-- Title -->
+            <control type="group">
+                <posx>40</posx>
+                
+                <!-- Position depends on whether plot is displayed or not: Skin.HasSetting(Hide_Plot) -->
+                <posy>560</posy>
+                <include>Animation_FadedByMenu</include>
+                <include>Animation_HiddenByInfo</include>
+                <include>Animation_OpenCloseFade</include>
+                <visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+                
+                <!-- Title (prefer clearlogo, then clearart, then label) -->
+                <control type="image">
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>310</width>
+                    <height>120</height>
+                    <aspectratio align="left" aligny="top">keep</aspectratio>
+                    <texture background="true">$INFO[ListItem.Art(clearlogo)]</texture>
+                    <visible>!IsEmpty(ListItem.Art(clearlogo))</visible>
+                </control>
+                <control type="image">
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>310</width>
+                    <height>120</height>
+                    <aspectratio align="left" aligny="top">keep</aspectratio>
+                    <texture background="true">$INFO[ListItem.Art(clearart)]</texture>
+                    <visible>IsEmpty(ListItem.Art(clearlogo)) + !IsEmpty(ListItem.Art(clearart))</visible>
+                </control>
+                <control type="fadelabel">
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>1200</width>
+                    <height>50</height>
+                    <align>left</align>
+                    <aligny>top</aligny>
+                    <scrollout>false</scrollout>
+                    <pauseatend>600</pauseatend>
+                    <scrollspeed>20</scrollspeed>
+                    <font>METF_TitleTextLarge</font>
+                    <textcolor>TitleText</textcolor>
+                    <label>$INFO[ListItem.Label]</label>
+                    <visible>IsEmpty(ListItem.Art(clearlogo)) + IsEmpty(ListItem.Art(clearart))</visible>
+                </control>
+            </control>
+            
+            <!-- Genre / Movie Set name and watched indicator -->
+            <control type="group"> <!-- For non-movies -->
+                <posx>40</posx>
+                <posy>560</posy>
+                
+                <include>Animation_FadedByMenu</include>
+                <include>Animation_HiddenByInfo</include>
+                <include>Animation_OpenCloseFade</include>
+                <visible>Container.Content(sets) | Container.Content(tvshows)</visible>
+                
+                <include>VideoFanartWall_GenreWatched</include>
+            </control>
+            <control type="group"> <!-- For movies -->
+                <posx>40</posx>
+                <posy>510</posy>
+                
+                <include>Animation_FadedByMenu</include>
+                <include>Animation_HiddenByInfo</include>
+                <include>Animation_OpenCloseFade</include>
+                <visible>Container.Content(movies)</visible>
+                
+                <include>VideoFanartWall_GenreWatched</include>
+            </control>
+            <!-- Further information -->
+            <control type="grouplist"> <!-- For tvshows -->
+                <posx>40</posx>
+                <posy>670</posy>
+                
+                <width>1200</width>
+                <height>30</height>
+                <align>center</align>
+                <itemgap>10</itemgap>
+                <orientation>horizontal</orientation>
+                <include>Animation_FadedByMenu</include>
+                <include>Animation_HiddenByInfo</include>
+                <include>Animation_OpenCloseFade</include>
+                <visible>Container.Content(tvshows)</visible>
+                <include>VisibleIfNotMovieSet</include>
+                
+                <include>VideoFanartWall_Info</include>
+            </control>
+            <control type="grouplist"> <!-- For movies -->
+                <posx>40</posx>
+                <posy>615</posy>
+                
+                <width>1200</width>
+                <height>30</height>
+                <align>center</align>
+                <itemgap>10</itemgap>
+                <orientation>horizontal</orientation>
+                <include>Animation_FadedByMenu</include>
+                <include>Animation_HiddenByInfo</include>
+                <include>Animation_OpenCloseFade</include>
+                <visible>Container.Content(movies)</visible>
+                <include>VisibleIfNotMovieSet</include>
+                
+                <include>VideoFanartWall_Info</include>
+            </control>
+            
+            <include>ScrollBar_Horizontal</include>
+        </control>
+    </include>
 </includes>


### PR DESCRIPTION
Hi,

I created a new view for videos (movies, tvshows) that uses the fanart fullscreen (minus the info area on the bottom). In the bottom area not the plot is shown but the title (using clearart, clearlogo or just text - whatever is available) and further information.
What is missing is localization (I left two TODOs in the code) for the view's name. I am not sure how to do this. This might be an easy thing for you if you choose to include this in Metropolis.

If you think this is a nice addition to your skin, please merge. 
If you do not like it, this is fine as well. Feel free to reject this.

Thanks for your work!

Marcel
